### PR TITLE
Update buddy.js - Experimenting with Hit-All

### DIFF
--- a/lib/filter/buddy.js
+++ b/lib/filter/buddy.js
@@ -123,9 +123,48 @@ exports.update = function (json) {
     /**
      * Changes attacks
      */
-    // Hits everyone - Seems to not work
-    json[buddy].abilities[0].options.target_method = 6;
-    for (var ability in json[buddy].abilities) {
+  // Hits everyone - Seems to not work (EXPERIMENTAL - Changes Materia to all chars to Zealot, and adds a new form of "Attack")
+  json[buddy].materias = [{
+	  "arg2": "30151011",
+	  "effect_type": "13",
+	  "arg1": "100",
+	  "arg4": "0",
+	  "arg3": "0",
+	  "arg5": "0",
+	  "slot": 1
+	}];
+				
+	json[buddy].abilities.push({
+	  "category_id": "5",
+	  "options": {
+	    "alias_name": "",
+	    "panel_name": "Attack",
+	    "arg4": "0",
+	    "target_segment": "1",
+	    "arg7": "0",
+	    "status_ailments_id": "0",
+	    "arg9": "0",
+	    "counter_enable": "1",
+	    "arg1": "60",
+	    "arg10": "0",
+	    "target_range": "2",
+	    "target_death": "1",
+	    "name": "Attack",
+	    "arg3": "0",
+	    "cast_time": "1500",
+	    "arg8": "0",
+	    "arg6": "0",
+	    "arg2": "1",
+	    "target_method": "6",
+	    "active_target_method": "2",
+	    "status_ailments_factor": "0",
+	    "arg5": "0",
+	    "ability_animation_id": "0"
+	    },
+	  "exercise_type": "1",
+	  "action_id": "3",
+	  "ability_id": "30151011"}
+	);
       /*
        * Quick attack
        * Does not work under normal attack.


### PR DESCRIPTION
Managed to find a way to add Materia to everyone for Zealot and introduce the new form of "attack" which will hit all targets.