### PR TITLE
Infinity abilities bug fix for buddy.js

### DIFF
--- a/lib/filter/buddy.js
+++ b/lib/filter/buddy.js
@@ -3,6 +3,7 @@
  * Modified by /u/mba199
  * Modified again on 11/8/2015 by SirPhoenix88
  * Modified on 1/12/2016 by SirPhoenix88
+ * Modified on 2/1/2016 by SirPhoenix88 
  */
 
 var Table = require('cli-table');
@@ -137,10 +138,11 @@ exports.update = function (json) {
     /*
      * Ability spammer
      * Fills soulbreak gauge one full unit per ability
+     * Number of uses set to 20, setting to '0' (infinity) creates bugs, and they refill every round of a stage
      */
     for (var panel in json[buddy].ability_panels) {
-      json[buddy].ability_panels[panel].num = '0';
-      json[buddy].ability_panels[panel].max_num = '0';
+      json[buddy].ability_panels[panel].num = '20';
+      json[buddy].ability_panels[panel].max_num = '20';
       json[buddy].ability_panels[panel].ability_ss_point = '500'
     }
     /*

--- a/lib/filter/buddy.js
+++ b/lib/filter/buddy.js
@@ -56,9 +56,12 @@ exports.update = function (json) {
     tmpRow.push(json[buddy].params[0].disp_name);
     tmpRow.push(json[buddy].id);
     tmpRow.push(json[buddy].no);
-
+    
+    /**
+     * Refill HP every round, also has unintentional beneficial side effect of raising dead party members between rounds. 
+     */
     tmp = json[buddy].init_hp;
-    json[buddy].init_hp = parseInt(json[buddy].init_hp);
+    json[buddy].init_hp = parseInt(json[buddy].max_hp);
     tmpRow.push(tmp + '/' + json[buddy].max_hp);
 
     tmp = json[buddy].params[0].atk;

--- a/lib/filter/buddy.js
+++ b/lib/filter/buddy.js
@@ -144,7 +144,7 @@ exports.update = function (json) {
       if (json[buddy].ability_panels[panel].ability_id != '30151001') {
         json[buddy].ability_panels[panel].num = '20';
         json[buddy].ability_panels[panel].max_num = '20';
-      {
+      }
       json[buddy].ability_panels[panel].ability_ss_point = '500'
     }
     /*

--- a/lib/filter/buddy.js
+++ b/lib/filter/buddy.js
@@ -141,8 +141,10 @@ exports.update = function (json) {
      * Number of uses set to 20, setting to '0' (infinity) creates bugs, and they refill every round of a stage
      */
     for (var panel in json[buddy].ability_panels) {
-      json[buddy].ability_panels[panel].num = '20';
-      json[buddy].ability_panels[panel].max_num = '20';
+      if (json[buddy].ability_panels[panel].ability_id != '30151001') {
+        json[buddy].ability_panels[panel].num = '20';
+        json[buddy].ability_panels[panel].max_num = '20';
+      {
       json[buddy].ability_panels[panel].ability_ss_point = '500'
     }
     /*


### PR DESCRIPTION
Fixes the bug. Limits number of abilities but sets the number to more than players should ever need per stage part.