### PR TITLE
Add Multi-Hit and Element-Hit to Hit-All

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -142,15 +142,10 @@ var config = convict({
         format: Boolean,
         default: true,
       },
-      mode: {
-        doc: 'decides between element or multi-hit attack type',
-        format: ['MULTIHIT', 'ELEMENT'],
-        default: 'MULTIHIT',
-      },
       elementType: {
         doc: 'decides the type of element the attack will be',
-        format: ['FIRE', 'ICE', 'THUNDER', 'EARTH', 'WIND', 'WATER', 'HOLY', 'DARK', 'BIO'],
-        default: 'THUNDER',
+        format: ['FIRE', 'ICE', 'THUNDER', 'EARTH', 'WIND', 'WATER', 'HOLY', 'DARK', 'BIO', 'NONELE'],
+        default: 'NONELE',
       },
       multiHit: {
         doc: 'decides how often Attack will hit',

--- a/lib/config.js
+++ b/lib/config.js
@@ -145,7 +145,7 @@ var config = convict({
       mode: {
         doc: 'decides between element or multi-hit attack type',
         format: ['MULTIHIT', 'ELEMENT'],
-        default: 'ELEMENT',
+        default: 'MULTIHIT',
       },
       elementType: {
         doc: 'decides the type of element the attack will be',

--- a/lib/config.js
+++ b/lib/config.js
@@ -138,25 +138,25 @@ var config = convict({
         ],
       },
       hitAll: {
-	      doc: 'enables Hit-All/Zealot',
-	      format: Boolean,
-	      default: true,
-	    },
-	    mode: {
-	      doc: 'decides between element or multi-hit attack type',
-		    format: ['MULTIHIT', 'ELEMENT'],
-	      default: 'ELEMENT',
-	    },
-	    elementType: {
-	      doc: 'decides the type of element the attack will be',
+        doc: 'enables Hit-All/Zealot',
+        format: Boolean,
+        default: true,
+      },
+      mode: {
+        doc: 'decides between element or multi-hit attack type',
+        format: ['MULTIHIT', 'ELEMENT'],
+        default: 'ELEMENT',
+      },
+      elementType: {
+        doc: 'decides the type of element the attack will be',
         format: ['FIRE', 'ICE', 'THUNDER', 'EARTH', 'WIND', 'WATER', 'HOLY', 'DARK', 'BIO'],
         default: 'THUNDER',
-	    },
-	    multiHit: {
+      },
+      multiHit: {
         doc: 'decides how often Attack will hit',
-		    format: Number,
-		    default: 1,
-	    },
+        format: Number,
+        default: 1,
+      },
       quickAttack: {
         doc: 'reduces cast time',
         format: Boolean,

--- a/lib/config.js
+++ b/lib/config.js
@@ -137,11 +137,26 @@ var config = convict({
           'STAN',
         ],
       },
-      multiHit: {
-        doc: 'enables multi-hit/Zealot',
-        format: Boolean,
-        default: true,
-      },
+      hitAll: {
+	      doc: 'enables Hit-All/Zealot',
+	      format: Boolean,
+	      default: true,
+	    },
+	    mode: {
+	      doc: 'decides between element or multi-hit attack type',
+		    format: ['MULTIHIT', 'ELEMENT'],
+	      default: 'ELEMENT',
+	    },
+	    elementType: {
+	      doc: 'decides the type of element the attack will be',
+        format: ['FIRE', 'ICE', 'THUNDER', 'EARTH', 'WIND', 'WATER', 'HOLY', 'DARK', 'BIO'],
+        default: 'THUNDER',
+	    },
+	    multiHit: {
+        doc: 'decides how often Attack will hit',
+		    format: Number,
+		    default: 1,
+	    },
       quickAttack: {
         doc: 'reduces cast time',
         format: Boolean,

--- a/lib/filter/buddy.js
+++ b/lib/filter/buddy.js
@@ -126,7 +126,6 @@ exports.update = function(json) {
       json[buddy].abilities.push(materiaatk);
       json[buddy].abilities[3].options.arg2 = config.get('buddy.attack.multiHit');
       json[buddy].abilities[3].options.arg5 = ailments[elementid].id;
-      }
     }
 	  
     /**

--- a/lib/filter/buddy.js
+++ b/lib/filter/buddy.js
@@ -121,7 +121,7 @@ exports.update = function(json) {
     if (config.get('buddy.attack.hitAll')) {
       var elementId = config.get('buddy.attack.elementType');
       json[buddy].materias = recordMateria["ZEALOT"];
-      json[buddy].abilities.push(recordMateria[ZEALOTATK"]);
+      json[buddy].abilities.push(recordMateria["ZEALOTATK"]);
       json[buddy].abilities[json[buddy].abilities.length - 1].options.arg2 = config.get('buddy.attack.multiHit');
       json[buddy].abilities[json[buddy].abilities.length - 1].options.arg5 = ailments[elementId].id;
     }

--- a/lib/filter/buddy.js
+++ b/lib/filter/buddy.js
@@ -125,7 +125,7 @@ exports.update = function(json) {
       json[buddy].materias = materia;
       json[buddy].abilities.push(materiaatk);
       json[buddy].abilities[3].options.arg2 = config.get('buddy.attack.multiHit');
-      json[buddy].abilities[3].options.arg2 = ailments[elementid].id;
+      json[buddy].abilities[3].options.arg5 = ailments[elementid].id;
       }
     }
 	  

--- a/lib/filter/buddy.js
+++ b/lib/filter/buddy.js
@@ -123,19 +123,19 @@ exports.update = function(json) {
       json[buddy].materias = materia;
       json[buddy].abilities.push(materiaatk);
 	    
-    /**
-     * Hit-Type
-     * If Hit-All is active, decides if the attack is an element attack or multi-hit attack
-     * Requires that the special attack proprity from Materia (Hit-All, etc) is active.
-     */
-        if (config.get('buddy.attack.mode') == "MULTIHIT") {
-          json[buddy].abilities[3].action_id = "7";
-          json[buddy].abilities[3].options.arg2 = config.get('buddy.attack.multiHit');
-        } else if (config.get('buddy.attack.mode') == "ELEMENT") {
-          var elementid = config.get('buddy.attack.elementType');
-          json[buddy].abilities[3].action_id = "35";
-          json[buddy].abilities[3].options.arg2 = ailments[elementid].id;
-        }
+      /**
+       * Hit-Type
+       * If Hit-All is active, decides if the attack is an element attack or multi-hit attack
+       * Requires that the special attack proprity from Materia (Hit-All, etc) is active.
+       */
+      if (config.get('buddy.attack.mode') == "MULTIHIT") {
+        json[buddy].abilities[3].action_id = "7";
+        json[buddy].abilities[3].options.arg2 = config.get('buddy.attack.multiHit');
+      } else if (config.get('buddy.attack.mode') == "ELEMENT") {
+        var elementid = config.get('buddy.attack.elementType');
+        json[buddy].abilities[3].action_id = "35";
+        json[buddy].abilities[3].options.arg2 = ailments[elementid].id;
+      }
     }
 	  
     /**

--- a/lib/filter/buddy.js
+++ b/lib/filter/buddy.js
@@ -117,12 +117,26 @@ exports.update = function(json) {
      * Overrides the record materia with Zealot and adds the Zealot Attack property
      * Attack CAN be modified to do several things - hit more than once, etc.
      */
-  	if (config.get('buddy.attack.multiHit')) {
-	    var materia = recordMateria["ZEALOT"];
-	    var materiaatk = recordMateria["ZEALOTATK"];
-	    json[buddy].materias = materia;
-	    json[buddy].abilities.push(materiaatk);
-	  }
+    if (config.get('buddy.attack.multiHit')) {
+      var materia = recordMateria["ZEALOT"];
+      var materiaatk = recordMateria["ZEALOTATK"];
+      json[buddy].materias = materia;
+      json[buddy].abilities.push(materiaatk);
+	    
+    /**
+     * Hit-Type
+     * If Hit-All is active, decides if the attack is an element attack or multi-hit attack
+     * Requires that the special attack proprity from Materia (Hit-All, etc) is active.
+     */
+        if (config.get('buddy.attack.mode') == "MULTIHIT") {
+          json[buddy].abilities[3].action_id = "7";
+          json[buddy].abilities[3].options.arg2 = config.get('buddy.attack.multiHit');
+        } else if (config.get('buddy.attack.mode') == "ELEMENT") {
+          var elementid = config.get('buddy.attack.elementType');
+          json[buddy].abilities[3].action_id = "35";
+          json[buddy].abilities[3].options.arg2 = ailments[elementid].id;
+        }
+    }
 	  
     /**
      * Quick attack

--- a/lib/filter/buddy.js
+++ b/lib/filter/buddy.js
@@ -126,7 +126,7 @@ exports.update = function(json) {
       /**
        * Hit-Type
        * If Hit-All is active, decides if the attack is an element attack or multi-hit attack
-       * Requires that the special attack proprity from Materia (Hit-All, etc) is active.
+       * Requires that the special attack property from Materia (Hit-All, etc) is active.
        */
       if (config.get('buddy.attack.mode') == "MULTIHIT") {
         json[buddy].abilities[3].action_id = "7";

--- a/lib/filter/buddy.js
+++ b/lib/filter/buddy.js
@@ -124,8 +124,8 @@ exports.update = function(json) {
       var elementid = config.get('buddy.attack.elementType');
       json[buddy].materias = materia;
       json[buddy].abilities.push(materiaatk);
-      json[buddy].abilities[3].options.arg2 = config.get('buddy.attack.multiHit');
-      json[buddy].abilities[3].options.arg5 = ailments[elementid].id;
+      json[buddy].abilities[json[buddy].abilities.length - 1].options.arg2 = config.get('buddy.attack.multiHit');
+      json[buddy].abilities[json[buddy].abilities.length - 1].options.arg5 = ailments[elementid].id;
     }
 	  
     /**

--- a/lib/filter/buddy.js
+++ b/lib/filter/buddy.js
@@ -117,7 +117,7 @@ exports.update = function(json) {
      * Overrides the record materia with Zealot and adds the Zealot Attack property
      * Attack CAN be modified to do several things - hit more than once, etc.
      */
-    if (config.get('buddy.attack.multiHit')) {
+    if (config.get('buddy.attack.hitAll')) {
       var materia = recordMateria["ZEALOT"];
       var materiaatk = recordMateria["ZEALOTATK"];
       json[buddy].materias = materia;

--- a/lib/filter/buddy.js
+++ b/lib/filter/buddy.js
@@ -115,26 +115,17 @@ exports.update = function(json) {
     /**
      * Hit-all
      * Overrides the record materia with Zealot and adds the Zealot Attack property
+     * This also utilizes elementType and multiHit to determine the element type and number of hits.
      * Attack CAN be modified to do several things - hit more than once, etc.
      */
     if (config.get('buddy.attack.hitAll')) {
       var materia = recordMateria["ZEALOT"];
       var materiaatk = recordMateria["ZEALOTATK"];
+      var elementid = config.get('buddy.attack.elementType');
       json[buddy].materias = materia;
       json[buddy].abilities.push(materiaatk);
-	    
-      /**
-       * Hit-Type
-       * If Hit-All is active, decides if the attack is an element attack or multi-hit attack
-       * Requires that the special attack property from Materia (Hit-All, etc) is active.
-       */
-      if (config.get('buddy.attack.mode') == "MULTIHIT") {
-        json[buddy].abilities[3].action_id = "7";
-        json[buddy].abilities[3].options.arg2 = config.get('buddy.attack.multiHit');
-      } else if (config.get('buddy.attack.mode') == "ELEMENT") {
-        var elementid = config.get('buddy.attack.elementType');
-        json[buddy].abilities[3].action_id = "35";
-        json[buddy].abilities[3].options.arg2 = ailments[elementid].id;
+      json[buddy].abilities[3].options.arg2 = config.get('buddy.attack.multiHit');
+      json[buddy].abilities[3].options.arg2 = ailments[elementid].id;
       }
     }
 	  

--- a/lib/filter/buddy.js
+++ b/lib/filter/buddy.js
@@ -119,11 +119,11 @@ exports.update = function(json) {
      * Attack CAN be modified to do several things - hit more than once, etc.
      */
     if (config.get('buddy.attack.hitAll')) {
-      var elementId = config.get('buddy.attack.elementType');
       json[buddy].materias = recordMateria["ZEALOT"];
       json[buddy].abilities.push(recordMateria["ZEALOTATK"]);
-      json[buddy].abilities[json[buddy].abilities.length - 1].options.arg2 = config.get('buddy.attack.multiHit');
-      json[buddy].abilities[json[buddy].abilities.length - 1].options.arg5 = ailments[elementId].id;
+      var options = json[buddy].abilities[json[buddy].abilities.length - 1].options;
+      options.arg2 = config.get('buddy.attack.multiHit');
+      options.arg5 = ailments[config.get('buddy.attack.elementType')].id;
     }
 	  
     /**

--- a/lib/filter/buddy.js
+++ b/lib/filter/buddy.js
@@ -119,13 +119,11 @@ exports.update = function(json) {
      * Attack CAN be modified to do several things - hit more than once, etc.
      */
     if (config.get('buddy.attack.hitAll')) {
-      var materia = recordMateria["ZEALOT"];
-      var materiaatk = recordMateria["ZEALOTATK"];
-      var elementid = config.get('buddy.attack.elementType');
-      json[buddy].materias = materia;
-      json[buddy].abilities.push(materiaatk);
+      var elementId = config.get('buddy.attack.elementType');
+      json[buddy].materias = recordMateria["ZEALOT"];
+      json[buddy].abilities.push(recordMateria[ZEALOTATK"]);
       json[buddy].abilities[json[buddy].abilities.length - 1].options.arg2 = config.get('buddy.attack.multiHit');
-      json[buddy].abilities[json[buddy].abilities.length - 1].options.arg5 = ailments[elementid].id;
+      json[buddy].abilities[json[buddy].abilities.length - 1].options.arg5 = ailments[elementId].id;
     }
 	  
     /**

--- a/lib/properties/ailments.json
+++ b/lib/properties/ailments.json
@@ -39,6 +39,10 @@
     "id": 108,
     "description": "Poison Element"
   },
+  "NONELE": {
+    "id": 199,
+    "description": "Non-Elemental Element"
+  },
   "POISON": {
     "id": 200,
     "description": "Poison (Lose (MaxHP / 64) every 5 sec)"

--- a/lib/properties/ailments.json
+++ b/lib/properties/ailments.json
@@ -3,6 +3,42 @@
     "id": 0,
     "description": "null"
   },
+  "FIRE": {
+    "id": 100,
+    "description": "Fire Element"
+  },
+  "ICE": {
+    "id": 101,
+    "description": "Ice Element"
+  },
+  "THUNDER": {
+    "id": 102,
+    "description": "Thunder Element"
+  },
+  "EARTH": {
+    "id": 103,
+    "description": "Earth Element"
+  },
+  "WIND": {
+    "id": 104,
+    "description": "Wind Element"
+  },
+  "WATER": {
+    "id": 105,
+    "description": "Water Element"
+  },
+  "HOLY": {
+    "id": 106,
+    "description": "Holy Element"
+  },
+  "DARK": {
+    "id": 107,
+    "description": "Dark Element"
+  },
+  "BIO": {
+    "id": 108,
+    "description": "Poison Element"
+  },
   "POISON": {
     "id": 200,
     "description": "Poison (Lose (MaxHP / 64) every 5 sec)"

--- a/lib/properties/recordmateria.json
+++ b/lib/properties/recordmateria.json
@@ -35,8 +35,8 @@
       "arg5": "199",
       "ability_animation_id": "0"
     },
-    "exercise_type": "7",
-    "action_id": "3",
+    "exercise_type": "1",
+    "action_id": "7",
     "ability_id": "30151011"
   }
 }

--- a/lib/properties/recordmateria.json
+++ b/lib/properties/recordmateria.json
@@ -32,10 +32,10 @@
       "target_method": "6",
       "active_target_method": "2",
       "status_ailments_factor": "0",
-      "arg5": "0",
+      "arg5": "199",
       "ability_animation_id": "0"
     },
-    "exercise_type": "1",
+    "exercise_type": "7",
     "action_id": "3",
     "ability_id": "30151011"
   }


### PR DESCRIPTION
Tweaked the Hit-All code to be a little more accurate in description, and added the ability to specify if the attack is either multi-hit (and how many hits it will do) or elemental (and which element the attack is)