### PR TITLE
Update enemy.js - Vulnerability fix

### DIFF
--- a/lib/filter/enemy.js
+++ b/lib/filter/enemy.js
@@ -123,10 +123,9 @@ exports.update = function(json) {
             }
           }
           currentEnemy.params[0].def_attributes = newDefAttr;
-            
-          if (currentEnemy.params[0].def_attributes.length == 0) {
-            buffs = 'None';
-          } else {
+          buffs = displayAttr;
+          
+          if (currentEnemy.params[0].def_attributes.length != 0) {
             buffs = displayAttr;
           }
         }

--- a/lib/filter/enemy.js
+++ b/lib/filter/enemy.js
@@ -82,11 +82,13 @@ exports.update = function(json) {
         rows.push(currentEnemyOri.params[0].spd + '>' + currentEnemy.params[0].spd);
 
         var buffs = '';
+        
         if (config.get('enemy.defAttributes.enabled')) {
           var newDefAttr = [];
           var displayAttr = [];
           for (var att in json[round].enemy[enemy].children[part].params[0].def_attributes) {
             var attributes = json[round].enemy[enemy].children[part].params[0].def_attributes[att]
+            
             if (attributes.attribute_id < 200 && attributes.factor == 1) {
               newDefAttr.push(attributes);
               switch (attributes.attribute_id) {
@@ -117,11 +119,11 @@ exports.update = function(json) {
                 default:
                   displayAttr.push("Poison");
                   break;
-                }
               }
             }
+          }
           currentEnemy.params[0].def_attributes = newDefAttr;
-          
+            
           if (currentEnemy.params[0].def_attributes.length == 0) {
             buffs = 'None';
           } else {

--- a/lib/filter/enemy.js
+++ b/lib/filter/enemy.js
@@ -83,49 +83,49 @@ exports.update = function(json) {
 
         var buffs = '';
         if (config.get('enemy.defAttributes.enabled')) {
-          var NewDefAttrib = [];
-          var DisplayAttrib = [];
+          var newDefAttr = [];
+          var displayAttr = [];
           for (var att in json[round].enemy[enemy].children[part].params[0].def_attributes) {
             var attributes = json[round].enemy[enemy].children[part].params[0].def_attributes[att]
             if (attributes.attribute_id < 200 && attributes.factor == 1) {
-              NewDefAttrib.push(attributes);
+              newDefAttr.push(attributes);
               switch (attributes.attribute_id) {
               	case "100":
-                  DisplayAttrib.push("Fire");
+                  displayAttr.push("Fire");
                   break;
                 case "101":
-                  DisplayAttrib.push("Ice");
+                  displayAttr.push("Ice");
                   break;
                 case "102":
-                  DisplayAttrib.push("Thunder");
+                  displayAttr.push("Thunder");
                   break;
                 case "103":
-                  DisplayAttrib.push("Earth");
+                  displayAttr.push("Earth");
                   break;
                 case "104":
-                  DisplayAttrib.push("Wind");
+                  displayAttr.push("Wind");
                   break;
                 case "105":
-                  DisplayAttrib.push("Water");
+                  displayAttr.push("Water");
                   break;
                 case "106":
-                  DisplayAttrib.push("Holy");
+                  displayAttr.push("Holy");
                   break;
                 case "107":
-                  DisplayAttrib.push("Dark");
+                  displayAttr.push("Dark");
                   break;
                 default:
-                  DisplayAttrib.push("Poison");
+                  displayAttr.push("Poison");
                   break;
                 }
               }
             }
-          currentEnemy.params[0].def_attributes = NewDefAttrib;
+          currentEnemy.params[0].def_attributes = newDefAttr;
           
           if (currentEnemy.params[0].def_attributes.length == 0) {
             buffs = 'None';
           } else {
-            buffs = DisplayAttrib;
+            buffs = displayAttr;
           }
         }
 

--- a/lib/filter/enemy.js
+++ b/lib/filter/enemy.js
@@ -22,7 +22,7 @@ exports.update = function(json) {
         'acc',
         'eva',
         'spd',
-        'extra',
+        'weakness',
         'drops',
       ],
       chars: {
@@ -83,12 +83,49 @@ exports.update = function(json) {
 
         var buffs = '';
         if (config.get('enemy.defAttributes.enabled')) {
-          currentEnemy.params[0].def_attributes = config.get('enemy.defAttributes.attributes');
-
+          var NewDefAttrib = [];
+          var DisplayAttrib = [];
+          for (var att in json[round].enemy[enemy].children[part].params[0].def_attributes) {
+            var attributes = json[round].enemy[enemy].children[part].params[0].def_attributes[att]
+            if (attributes.attribute_id < 200 && attributes.factor == 1) {
+              NewDefAttrib.push(attributes);
+              switch (attributes.attribute_id) {
+              	case "100":
+                  DisplayAttrib.push("Fire");
+                  break;
+                case "101":
+                  DisplayAttrib.push("Ice");
+                  break;
+                case "102":
+                  DisplayAttrib.push("Thunder");
+                  break;
+                case "103":
+                  DisplayAttrib.push("Earth");
+                  break;
+                case "104":
+                  DisplayAttrib.push("Wind");
+                  break;
+                case "105":
+                  DisplayAttrib.push("Water");
+                  break;
+                case "106":
+                  DisplayAttrib.push("Holy");
+                  break;
+                case "107":
+                  DisplayAttrib.push("Dark");
+                  break;
+                default:
+                  DisplayAttrib.push("Poison");
+                  break;
+                }
+              }
+            }
+          currentEnemy.params[0].def_attributes = NewDefAttrib;
+          
           if (currentEnemy.params[0].def_attributes.length == 0) {
-            buffs = 'Debuffed';
+            buffs = 'None';
           } else {
-            buffs = currentEnemy.params[0].def_attributes.join(', ');
+            buffs = DisplayAttrib;
           }
         }
 


### PR DESCRIPTION
Initial attempt to fix and leave Vulnerability on enemies - easier to confirm if target conditions are met. This is workaround code for the current setup. May be tidied up in the future, but currently I have nothing in the way of getting away from the switch condition to display elemental weakness. Does not display all due to size of some entries.