### PR TITLE
Update enemy.js

### DIFF
--- a/lib/filter/enemy.js
+++ b/lib/filter/enemy.js
@@ -134,6 +134,8 @@ exports.update = function(json) {
 
             if (item.type == 11) {
               drops.push('Gold: ' + item.amount);
+            } else if (item.type == 61) {
+              drops.push('Greens: ' + item.num);
             } else {
               drops.push(inventory[item.item_id] + ' (' + item.rarity + '*)');
             }

--- a/lib/filter/enemy.js
+++ b/lib/filter/enemy.js
@@ -135,7 +135,7 @@ exports.update = function(json) {
             if (item.type == 11) {
               drops.push('Gold: ' + item.amount);
             } else if (item.type == 61) {
-              drops.push('Greens: ' + item.num);
+              drops.push('Gysahl Greens: ' + item.num);
             } else {
               drops.push(inventory[item.item_id] + ' (' + item.rarity + '*)');
             }


### PR DESCRIPTION
Added an item type for Greens dropped in the new daily dungeons, and tied to the number of total greens dropped (pretty sure this is a fixed value per dungeon, but wth not pull it from the json).

This is not yet tested - just creating the initial patch to confirm if this works as anticipated.