### PR TITLE
Add cert as a command line argument

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -60,6 +60,8 @@ var config = convict({
         doc: 'port to bind',
         format: 'port',
         default: 5051,
+        env: 'CERT',
+        arg: 'cert',
       },
     },
     dump: {

--- a/lib/config.js
+++ b/lib/config.js
@@ -60,8 +60,8 @@ var config = convict({
         doc: 'port to bind',
         format: 'port',
         default: 5051,
-        env: 'CERT',
-        arg: 'cert',
+        env: 'CERT_PORT',
+        arg: 'cert-port',
       },
     },
     dump: {


### PR DESCRIPTION
Allows passing --cert XXXX to define cert port at runtime.