### PR TITLE
fix docker build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -396,7 +396,7 @@
       }
     },
     "cli-table": {
-      "version": "git+ssh://git@github.com/Automattic/cli-table.git#7b14232ba779929e1859b267bf753c150d90a618",
+      "version": "git+https://git@github.com/Automattic/cli-table.git#7b14232ba779929e1859b267bf753c150d90a618",
       "requires": {
         "chalk": "2.4.1",
         "wcwidth": "1.0.1"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "babel-cli": "^6.26.0",
     "babel-plugin-inline-json": "^1.2.2",
     "chalk": "^2.4.1",
-    "cli-table": "git+ssh://git@github.com/Automattic/cli-table.git",
+    "cli-table": "git+https://git@github.com/Automattic/cli-table.git",
     "convict": "^4.4.0",
     "js-yaml": "^3.12.0",
     "node-forge": "^0.6.49",


### PR DESCRIPTION
Using `git+ssh://` in `package{,-lock}.json` is just not suitable for deploying ffrk-proxy in a container. By simply switching to `git+https://` the container then builds and runs perfectly, even on a Raspberry Pi running Docker! 😎